### PR TITLE
set_resource and set_parent_resource callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Following [Switch Dreams's](https://www.switchdreams.com.br/]) coding practices,
 - [Resource pagination](#pagination)
 - [Resource serialization](#serialization)
 - [Configurable](#configuration)
+- [Callbacks](#callbacks)
 
 ## Next Features
 
@@ -355,6 +356,26 @@ end
 The gem is tested with [panko serializer](https://github.com/panko-serializer/panko_serializer)
 and [ams](https://github.com/rails-api/active_model_serializers). But should works with any serializer, feel free to add
 tests for your favorite serializer.
+
+#### Callbacks
+
+You can use the callbacks in the controller to add some logic before, around or after `set_resource`
+or `set_parent_resource`:
+
+```ruby
+# frozen_string_literal: true
+
+class CarsController < RestApiGenerator::ResourceController
+  after_set_resource :authorize_logic
+
+  def authorize_logic
+    # Custom authorization logic
+    # authorize! :manage, @resource
+  end
+end
+```
+
+This is essencial when you need to authorize the resource before any action.
 
 ## Configuration
 

--- a/app/controllers/rest_api_generator/child_resource_controller.rb
+++ b/app/controllers/rest_api_generator/child_resource_controller.rb
@@ -2,6 +2,7 @@
 
 module RestApiGenerator
   class ChildResourceController < RestApiGenerator.configuration.parent_controller.constantize
+    include ControllerCallbacks
     include Orderable
     include Serializable
 
@@ -74,11 +75,15 @@ module RestApiGenerator
 
     # Before actions
     def set_parent_resource
-      @parent_resource = parent_resource_class.find(parent_record_id)
+      run_callbacks :set_parent_resource do
+        @parent_resource = parent_resource_class.find(parent_record_id)
+      end
     end
 
     def set_resource
-      @resource = resources.find(record_id)
+      run_callbacks :set_resource do
+        @resource = resources.find(record_id)
+      end
     end
 
     # UsersController => User

--- a/app/controllers/rest_api_generator/resource_controller.rb
+++ b/app/controllers/rest_api_generator/resource_controller.rb
@@ -2,11 +2,11 @@
 
 module RestApiGenerator
   class ResourceController < RestApiGenerator.configuration.parent_controller.constantize
+    include ControllerCallbacks
     include Orderable
     include Serializable
 
     before_action :set_resource, only: [:show, :update, :destroy]
-
     def index
       @resources = resource_class.all
       @resources = @resources.filter_resource(params_for_filter) if resource_class.include?(Filterable)
@@ -63,7 +63,9 @@ module RestApiGenerator
     end
 
     def set_resource
-      @resource = resource_class.find(record_id)
+      run_callbacks :set_resource do
+        @resource = resource_class.find(record_id)
+      end
     end
 
     # UsersController => User

--- a/lib/rest_api_generator.rb
+++ b/lib/rest_api_generator.rb
@@ -9,6 +9,7 @@ require_relative "rest_api_generator/helpers/render"
 require_relative "rest_api_generator/filterable"
 require_relative "rest_api_generator/orderable"
 require_relative "rest_api_generator/serializable"
+require_relative "rest_api_generator/controller_callbacks"
 
 module RestApiGenerator
   class Error < StandardError; end

--- a/lib/rest_api_generator/controller_callbacks.rb
+++ b/lib/rest_api_generator/controller_callbacks.rb
@@ -19,7 +19,7 @@ module RestApiGenerator
           end
         end
 
-        define_method "#{callback}_set_parent" do |*names, &blk|
+        define_method "#{callback}_set_parent_resource" do |*names, &blk|
           _insert_callbacks(names, blk) do |name, options|
             set_callback(:set_parent_resource, callback, name, options)
           end

--- a/lib/rest_api_generator/controller_callbacks.rb
+++ b/lib/rest_api_generator/controller_callbacks.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module RestApiGenerator
+  module ControllerCallbacks
+    extend ActiveSupport::Concern
+    include ActiveSupport::Callbacks
+
+    included do
+      define_callbacks :set_resource
+      define_callbacks :set_parent_resource
+    end
+
+    module ClassMethods
+      # Code from rails source code
+      [:before, :after, :around].each do |callback|
+        define_method "#{callback}_set_resource" do |*names, &blk|
+          _insert_callbacks(names, blk) do |name, options|
+            set_callback(:set_resource, callback, name, options)
+          end
+        end
+
+        define_method "#{callback}_set_parent" do |*names, &blk|
+          _insert_callbacks(names, blk) do |name, options|
+            set_callback(:set_parent_resource, callback, name, options)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/dummy/app/controllers/cars_controller.rb
+++ b/spec/dummy/app/controllers/cars_controller.rb
@@ -1,4 +1,10 @@
 # frozen_string_literal: true
 
 class CarsController < RestApiGenerator::ResourceController
+  after_set_resource :authorize_logic
+
+  def authorize_logic
+    # Custom authorization logic
+    # authorize! :manage, @resource
+  end
 end

--- a/spec/lib/rest_api_generator/resource_controller_spec.rb
+++ b/spec/lib/rest_api_generator/resource_controller_spec.rb
@@ -119,4 +119,21 @@ RSpec.describe "ResourceController", type: :request do
       end
     end
   end
+
+  describe "callbacks" do
+    context "when callbacks exists" do
+      it "calls callbacks" do
+        car = Car.create!(name: "Car")
+        controller = CarsController.new
+
+        allow(controller).to receive(:params).and_return(ActionController::Parameters.new({ id: car.id }))
+
+        # rubocop:disable RSpec/MessageSpies
+        expect(controller).to receive(:authorize_logic)
+        # rubocop:enable RSpec/MessageSpies
+
+        controller.send(:set_resource)
+      end
+    end
+  end
 end


### PR DESCRIPTION
New controller features for help authorization:

You can use the callbacks in the controller to add some logic before, around or after `set_resource`
or `set_parent_resource`:

```ruby
# frozen_string_literal: true

class CarsController < RestApiGenerator::ResourceController
  after_set_resource :authorize_logic

  def authorize_logic
    # Custom authorization logic
    # authorize! :manage, @resource
  end
end
```

closes #36 